### PR TITLE
Fix variables accessed in thread before initialization

### DIFF
--- a/lib/smbuilderthread.cc
+++ b/lib/smbuilderthread.cc
@@ -7,9 +7,9 @@
 
 using namespace SpectMorph;
 
-BuilderThread::BuilderThread() :
-  thread (&BuilderThread::run, this)
+BuilderThread::BuilderThread()
 {
+  thread = std::thread (&BuilderThread::run, this);
 }
 
 BuilderThread::~BuilderThread()


### PR DESCRIPTION
Hi, this is a subtle error in threading code which creates a race condition.

When the thread is started in the initializer list, it's possible that the `run` routine will access other members of the instance, before they have enough time to be initialized.
(assignment by = operator in the header, which act as implicit initializer)

In particular, `check_quit()` may evaluate as true, and thread will immediately stop itself.

A solution is to create the thread in the ctor body, after that all initializers have been processed.