### PR TITLE
Fix compile errors caused by __m128 and fnstcw on RISC-V

### DIFF
--- a/lib/smmath.cc
+++ b/lib/smmath.cc
@@ -78,8 +78,10 @@ sm_math_init()
       MathTables::ifreq2f_low[i]  = sm_ifreq2freq_slow (ADD + i);
     }
 
+#if defined (__i386__) && defined (__GNUC__)
   // ensure proper rounding mode
   assert (sm_fpu_okround());
+#endif
 
   assert (sm_round_positive (42.51) == 43);
   assert (sm_round_positive (3.14) == 3);
@@ -88,6 +90,7 @@ sm_math_init()
   assert (sm_round_positive (0.2) == 0);
 }
 
+#if defined (__i386__) && defined (__GNUC__)
 int
 sm_fpu_okround()
 {
@@ -98,6 +101,7 @@ sm_fpu_okround()
            : "=m" (*&cv));
   return !(cv & 0x0c00);
 }
+#endif
 
 double
 sm_lowpass1_factor (double mix_freq, double freq)

--- a/lib/smnoisedecoder.cc
+++ b/lib/smnoisedecoder.cc
@@ -313,8 +313,12 @@ NoiseDecoder::apply_window (float *spectrum, float *fft_buffer)
   else
 #endif
     {
+#if defined(__riscv)
+      alignas (16) float spectrum[block_size + 2]; // SSE alignment
+#else
       __m128 out[(block_size + 2) / 4 + 1];   // SSE alignment (should be done by compiler)
       float *spectrum = reinterpret_cast <float *> (&out[0]);
+#endif
       for (size_t i = 8; i < block_size + 2 + 8; i += 2)
         {
           float out_re = K0 * expand_in[i];


### PR DESCRIPTION
Closes #12 