### PR TITLE
LIB: fix invalid access to past last element

### DIFF
--- a/lib/smmorphplan.cc
+++ b/lib/smmorphplan.cc
@@ -247,7 +247,7 @@ MorphPlan::load_internal (GenericIn *in, ExtraParameters *params)
 
                   delete blob_in; // close blob file handle
 
-                  GenericIn *in = MMapIn::open_mem (&blob_data[0], &blob_data[blob_data.size()]);
+                  GenericIn *in = MMapIn::open_mem (&blob_data[0], &blob_data[0] + blob_data.size());
                   InFile blob_infile (in);
                   load_op->load (blob_infile);
 
@@ -271,7 +271,7 @@ MorphPlan::load_internal (GenericIn *in, ExtraParameters *params)
 
                   vector<unsigned char>& blob_data = blob_data_map[ifile.event_blob_sum()];
 
-                  GenericIn *in = MMapIn::open_mem (&blob_data[0], &blob_data[blob_data.size()]);
+                  GenericIn *in = MMapIn::open_mem (&blob_data[0], &blob_data[0] + blob_data.size());
                   InFile blob_infile (in);
                   load_op->load (blob_infile);
 


### PR DESCRIPTION
- Accessing a vector element past the last (idx >= size) is UB and will trigger an assertion when built with assertions


The plugin was aborting on load when built as a flatpak.
(default CXX flags have C++ assertions enabled)